### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cordova.plugins.firebase.messaging.onMessage(function(payload) {
     console.log("New foreground FCM message: ", payload);
 });
 ```
-NOTE: on iOS make sure notification payload contains key `content-available` with value `1`. Otherwise this callback is never fired.
+NOTE: on iOS make sure notification payload contains key `content_available` with value `true`. Otherwise this callback is never fired.
 
 ### onBackgroundMessage(_callback_)
 Called when a push message received while app is in background.
@@ -78,7 +78,7 @@ cordova.plugins.firebase.messaging.onBackgroundMessage(function(payload) {
     console.log("New background FCM message: ", payload);
 });
 ```
-NOTE: on iOS make sure notification payload contains key `content-available` with value `1`. Otherwise this callback is never fired.
+NOTE: on iOS make sure notification payload contains key `content_available` with value `true`. Otherwise this callback is never fired.
 
 ### requestPermission(_options_)
 Grant permission to recieve push notifications (will trigger prompt on iOS).


### PR DESCRIPTION
The value of the content-available for ios is misspelled and the value is a boolean set at true.
Firebase rejects the value when using https://fcm.googleapis.com/fcm/send